### PR TITLE
解决在diffview的快捷冲突

### DIFF
--- a/package.json
+++ b/package.json
@@ -691,7 +691,8 @@
             },
             {
                 "command": "Project.fastCompile",
-                "key": "f7"
+                "key": "f7",
+                "when": "!isInDiffEditor"
             }
         ],
         "menus": {


### PR DESCRIPTION
当打开diff视图时，eide 建议不要占用f7 快捷键。