### PR TITLE
Update the recommendation of Serial Monitor to hard dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Supported Platforms:
 * Provides many project templates for quick start a project.
 * Build, rebuild, support many toolchains (armcc, gcc-arm-none-eabi, riscv-gcc, xxx-gcc, keil_c51, sdcc ...).
 * Program flash, support: jlink, stlink, openocd, pyocd ...
-* ~~Built-in serial port monitor~~ (recommended to use `Serial Monitor` plug-in).
+* ~~Built-in serial port monitor~~ (Use the `Serial Monitor` extension, it will be installed when you install this extension!).
 * Supports static checking projects by using Cppcheck.
 * Automatically generates default debug configurations for debugger plug-in `cortex-debug, STM8-Debug`.
 * Built-in many utility tools, 'CMSIS Config Wizard UI', 'Disassembly view', 'Program resource view'...

--- a/package.json
+++ b/package.json
@@ -76,6 +76,9 @@
         "watch": "tsc -watch -p ./",
         "test": "npm run compile && node ./node_modules/vscode/bin/test"
     },
+    "extensionDependencies": [
+        "ms-vscode.vscode-serial-monitor"
+    ],
     "devDependencies": {
         "@types/ftp": "^0.3.31",
         "@types/iconv-lite": "0.0.1",


### PR DESCRIPTION
This would take a dependency on the Serial Monitor extension. This could make it easier for users to find the extension and use the [Serial Monitor](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-serial-monitor). 