### PR TITLE
Decouple eideDir from rootDir

### DIFF
--- a/src/EIDEProject.ts
+++ b/src/EIDEProject.ts
@@ -2937,17 +2937,33 @@ $(OUT_DIR):
         ////////////////////////////////////
         // init project
 
-        // init folders
-        this.rootDir = new File(wsFile.dir);
-        this.eideDir = new File(this.rootDir.path + File.sep + AbstractProject.EIDE_DIR);
+        // Fix: Decouple eideDir from rootDir so .eide/ config files can stay in the
+        //   user-selected workspace folder while rootDir can point to the Keil project
+        //   directory (for Keil imported projects). This ensures:
+        //   1) .eide/ config folder and .code-workspace are in the user-chosen location
+        //   2) rootDir (= project root for path resolution) is the Keil project directory
+        //   3) All relative paths resolve correctly relative to the Keil project folder
+        const wsDir = new File(wsFile.dir);
+        this.eideDir = new File(wsDir.path + File.sep + AbstractProject.EIDE_DIR);
 
-        // init cfgs
+        // init cfgs — load config BEFORE setting rootDir, so we can check miscInfo.keilPrjDir
         this.configMap.Set(new WorkspaceConfiguration(wsFile).load(), AbstractProject.workspaceSuffix);
-        const eideJsonFile = File.from(wsFile.dir, AbstractProject.EIDE_DIR, AbstractProject.prjConfigName);
+        const eideJsonFile = File.from(wsDir.path, AbstractProject.EIDE_DIR, AbstractProject.prjConfigName);
         this.configMap.Set(new ProjectConfiguration(eideJsonFile, this.workspaceState).load());
 
-        // create '.vscode' folder if it's not existed
-        File.fromArray([wsFile.dir, AbstractProject.vsCodeDir]).CreateDir(true);
+        // After config is loaded, determine rootDir:
+        // - For Keil imported projects: rootDir = keilPrjDir (the Keil project file's directory)
+        // - For normal projects: rootDir = wsFile.dir (the user-selected workspace folder)
+        const cfg = this.GetConfiguration().config;
+        const keilPrjDir = cfg.miscInfo?.keilPrjDir;
+        if (keilPrjDir) {
+            this.rootDir = new File(File.normalize(NodePath.resolve(wsDir.path, keilPrjDir)));
+        } else {
+            this.rootDir = wsDir;
+        }
+
+        // create '.vscode' folder if it's not existed — always next to .code-workspace
+        File.fromArray([wsDir.path, AbstractProject.vsCodeDir]).CreateDir(true);
 
         /////////////////////////////////////
         // init base builtin env

--- a/src/EIDEProjectExplorer.ts
+++ b/src/EIDEProjectExplorer.ts
@@ -2448,6 +2448,12 @@ class ProjectDataProvider implements vscode.TreeDataProvider<ProjTreeItem>, vsco
             folders: []
         };
 
+        // Fix: Store the Keil project file's directory in miscInfo.keilPrjDir.
+        //   This allows LoadConfigurations to set rootDir = keilPrjDir on next load,
+        //   so all path resolution uses the Keil project directory as the base.
+        //   The path is relative to user-selected folder (or absolute if cross-drive).
+        const keilPrjRelPath = baseInfo.rootFolder.ToRelativePath(keilPrjFile.dir);
+        projectInfo.miscInfo.keilPrjDir = keilPrjRelPath || keilPrjFile.dir;
         const getVirtualFolder = (path: string, noCreate?: boolean): VirtualFolder | undefined => {
 
             if (!path.startsWith(`${VirtualSource.rootName}/`)) {

--- a/src/EIDETypeDefine.ts
+++ b/src/EIDETypeDefine.ts
@@ -93,6 +93,7 @@ export interface DependenceGroup {
 
 export interface ProjectMiscInfo {
     uid: string | undefined;
+    keilPrjDir?: string; // Keil project file directory (relative to workspace root, or absolute if cross-drive)
 }
 
 export interface BuilderOptions {

--- a/src/KeilXmlParser.ts
+++ b/src/KeilXmlParser.ts
@@ -436,8 +436,13 @@ class C51Parser extends KeilParser<KeilC51Option> {
                         group.Files[0].File.forEach((node: { FileName: string, FileType: string, FilePath: string }) => {
                             const fPath = node.FilePath;
                             if (fPath !== undefined) {
+                                // Fix: Use raw XML path directly as-is (relative to keilPrjDir).
+                                //   Previously called this.ToAbsolutePath(fPath) which converted the
+                                //   XML relative path to absolute, then ImportKeilProject immediately
+                                //   converted it back to relative. This round-trip was redundant.
+                                //   The XML path is already relative to keilPrjFile.dir (= keilPrjDir).
                                 fGroup.files.push({
-                                    file: new File(this.ToAbsolutePath(fPath)),
+                                    file: new File(fPath),
                                     disabled: this.isFileDisabled(node)
                                 });
                             }
@@ -1082,8 +1087,9 @@ class ARMParser extends KeilParser<KeilARMOption> {
                         }) => {
                             const fPath = node.FilePath;
                             if (fPath !== undefined) {
+                                // Fix: Use raw XML path directly (relative to keilPrjDir).
                                 fGroup.files.push({
-                                    file: new File(this.ToAbsolutePath(fPath)),
+                                    file: new File(fPath),
                                     disabled: this.isFileDisabled(node)
                                 });
                                 // parse file options


### PR DESCRIPTION
问题描述:dev分支3.26.9, 编译命令的执行路径和eidedir一致.若是keil工程中使用了相对路径相对于keil工程文件所在文件夹路径.不在keil工程所在文件夹下进行编译, 可能会出现找不到源文件或头文件,从而导致编译失败的问题
实现功能: 固定rootdir为keil工程所在文件夹路径, 针对code-workspace和eide配置文件单独使用用户选择的文件夹路径.从而实现解耦