### PR TITLE
实现eide构建输出固件名和keil输出固件名相同,

### DIFF
--- a/src/CodeBuilder.ts
+++ b/src/CodeBuilder.ts
@@ -381,7 +381,12 @@ export abstract class CodeBuilder {
         const builderModeList: string[] = []; // build mode
 
         const builderOptions: BuilderParams = {
-            name: config.name,
+            // Fix#1: Builder's 'name' field determines the output filename (e.g., ${name}.axf).
+            //   Must use the current selected target name (config.mode) so the generated
+            //   axf file is named after the target (e.g., "Debug.axf") instead of the
+            //   project name ("myProject.axf"). The ExecutableName variable is correct
+            //   but the builder uses 'name' (not the env var) for ${out} resolution.
+            name: this.project.getCurrentTarget(),
             target: this.project.getCurrentTarget(),
             toolchain: toolchain.name,
             toolchainLocation: this.project.getToolchainLocation().path,

--- a/src/EIDEProject.ts
+++ b/src/EIDEProject.ts
@@ -895,8 +895,11 @@ export abstract class AbstractProject implements CustomConfigurationProvider, Pr
         return this.GetRootDir();
     }
 
+    // Fix#3: The generated axf filename should be the currently selected target name (config.mode),
+    //   NOT the project name (config.name). Previously used getProjectName() which produced
+    //   incorrect output filename like "myProject.axf" instead of "Debug.axf".
     public getExecutablePathWithoutSuffix(): string {
-        return [this.getRootDir().path, this.getOutputDir(), this.getProjectName()].join(File.sep);
+        return [this.getOutputFolder().path, this.getCurrentTarget()].join(File.sep);
     }
 
     /**

--- a/src/EIDEProjectExplorer.ts
+++ b/src/EIDEProjectExplorer.ts
@@ -7217,7 +7217,10 @@ export class ProjectExplorer implements CustomConfigurationProvider {
         type: 'jlink' | 'openocd' | 'pyocd',
         prj: AbstractProject, old_cfgs: any[]): Promise<{ debug_config: any, override_idx: number } | undefined> {
 
-        const _outFullName = File.ToUnixPath(prj.getOutputDir()) + '/' + `${prj.getProjectName()}`
+        // Fix: Use prj.getExecutablePathWithoutSuffix() to unify output file path calculation.
+        //   Previously called getExecutablePathWithoutSuffix() as a standalone function (no prj. prefix),
+        //   which would fail at runtime since it's a method on AbstractProject.
+        const _outFullName = File.ToUnixPath(prj.getExecutablePathWithoutSuffix())
         const _elfPath = `${_outFullName}.elf`;
         const _debugConfigTemplates = {
             'jlink': {

--- a/src/HexUploader.ts
+++ b/src/HexUploader.ts
@@ -234,9 +234,9 @@ export abstract class HexUploader<InvokeParamsType> {
         // if 'bin' path is empty, use default program path 
         if (options.bin.trim() === '') {
 
-            // relative path with './' prefix
+            // Fix: Use this.project.getExecutablePathWithoutSuffix() to unify output file path calculation.
             const hexPath = [
-                '.', this.project.getOutputDir(), this.project.getProjectName() + '.hex'
+                '.', this.project.getExecutablePathWithoutSuffix() + '.hex'
             ].join(File.sep);
 
             return [{ path: formatBinFilePath(hexPath) }];
@@ -1163,8 +1163,9 @@ class ProbeRSUploader extends HexUploader<string[]> {
         const matcher = /(?<path>[^,]+)(?:,(?<addr>0x[a-f0-9]+))?/i;
 
         // if 'bin' path is empty, use default program path 
-        if (options.bin.trim() === '') {
-            const elfPath = ['.', this.project.getOutputDir(), this.project.getProjectName() + '.elf'].join(File.sep);
+        if (options.bin.trim() === '') { 
+            // Fix: Use this.project.getExecutablePathWithoutSuffix() to unify output file path calculation.
+            const elfPath = ['.', this.project.getExecutablePathWithoutSuffix() + '.elf'].join(File.sep);
             return [
                 { path: elfPath }
             ];


### PR DESCRIPTION
问题描述:当前eide构建输出的固件名与keil工程名相同,而不是当前选中的target的名字.
实现效果:构建输出固件名为当前选中的target的名字