### PR TITLE
修复无法正确导入keil中group的构建参数的问题

### DIFF
--- a/src/EIDEProjectExplorer.ts
+++ b/src/EIDEProjectExplorer.ts
@@ -2520,10 +2520,142 @@ class ProjectDataProvider implements vscode.TreeDataProvider<ProjTreeItem>, vsco
             }
         };
 
+        // Helper: extract group options directly from Keil XML raw document.
+        //   This is a fallback when x2js-parsed groupOption is unavailable.
+        //   Reference: migrateKeilGroup2Eide.py
+        const rawKeilDoc = keilParser.getRawDoc();
+        const getRawGroupOpts = (groupName: string): { cads?: any, aads?: any } | undefined => {
+            try {
+                // Find the group in the raw XML document by name
+                for (const target of rawKeilDoc.Project.Targets.Target) {
+                    const groups = target.Groups;
+                    if (!groups || !groups.Group) continue;
+                    const rawGroup = groups.Group.find((g: any) => {
+                        const rawName = typeof g.GroupName === 'string' ? g.GroupName : g.GroupName?.__text;
+                        return KeilParser.FixGroupNameStatic(rawName) === groupName;
+                    });
+                    if (!rawGroup || !rawGroup.GroupOption) continue;
+                    const grpArmAds = rawGroup.GroupOption.GroupArmAds;
+                    if (!grpArmAds) continue;
+                    return {
+                        cads: grpArmAds.Cads,
+                        aads: grpArmAds.Aads
+                    };
+                }
+            } catch (e) {
+                // ignore parse errors
+            }
+        };
+
+        const setupGroupOpts = (vFolderPath: string, groupName: string) => {
+            for (const keilTarget of targets) {
+                if (srcOptsObj.options[keilTarget.name] == undefined)
+                    srcOptsObj.options[keilTarget.name] = { files: {}, virtualPathFiles: {} };
+                const targetSrcOpts = srcOptsObj.options[keilTarget.name];
+
+                const tGroup = keilTarget.fileGroups.find((g: any) => g.name === groupName);
+                let grpArmAds = tGroup?.groupOption?.GroupArmAds;
+
+                // Fallback: if x2js didn't parse GroupOption, read raw XML directly
+                if (!grpArmAds) {
+                    const rawOpts = getRawGroupOpts(groupName);
+                    if (rawOpts) {
+                        // Wrap raw opts in getFirst-compatible structure (x2js may create arrays)
+                        grpArmAds = {
+                            Cads: rawOpts.cads,
+                            Aads: rawOpts.aads
+                        };
+                    }
+                }
+
+                if (!grpArmAds) continue;
+
+                // Helper to extract first item if it is an array, else return the object itself
+                const getFirst = (obj: any) => Array.isArray(obj) ? obj[0] : obj;
+
+                // Process Cads
+                const cads = getFirst(grpArmAds.Cads);
+                if (cads && cads.VariousControls) {
+                    const c_fopts = getFirst(cads.VariousControls);
+                    if (c_fopts) {
+                        const optLi: string[] = [];
+                        const incText = getFirst(c_fopts.IncludePath);
+                        if (incText && typeof incText === 'string') {
+                            incText.split(';').map((s: string) => s.trim()).filter((s: string) => s).forEach((s: string) => {
+                                const rep = baseInfo.rootFolder.ToRelativePath(s) || s;
+                                if (keilTarget.type === 'C51') optLi.push(`INCDIR(${rep})`);
+                                else optLi.push(`-I${rep}`);
+                            });
+                        }
+                        const defText = getFirst(c_fopts.Define);
+                        if (defText && typeof defText === 'string') {
+                            defText.replace(/,/g, ' ').split(/\s+/).map((s: string) => s.trim()).filter((s: string) => s).forEach((item: string) => {
+                                if (keilTarget.type === 'C51') {
+                                    if (item.includes('=')) optLi.push(`DEFINE(${item})`);
+                                    else optLi.push(`DEFINE(${item}=1)`);
+                                } else optLi.push(`-D${item}`);
+                            });
+                        }
+                        const undefText = getFirst(c_fopts.Undefine);
+                        if (undefText && typeof undefText === 'string') {
+                            undefText.replace(/,/g, ' ').split(/\s+/).map((s: string) => s.trim()).filter((s: string) => s).forEach((item: string) => {
+                                if (keilTarget.type !== 'C51') optLi.push(`-U${item}`);
+                            });
+                        }
+                        const miscText = getFirst(c_fopts.MiscControls);
+                        if (miscText && typeof miscText === 'string') {
+                            const replMisc = miscText.replace(/(-imacros|-include)\s+([^\s]+)/g, (match: string, p1: string, p2: string) => {
+                                const relp = baseInfo.rootFolder.ToRelativePath(p2) || p2;
+                                return `${p1} ${relp}`;
+                            });
+                            optLi.push(replMisc.trim());
+                        }
+                        if (optLi.length > 0) {
+                            targetSrcOpts.virtualPathFiles = targetSrcOpts.virtualPathFiles || {};
+                            targetSrcOpts.virtualPathFiles[`${vFolderPath}/**/*.c`] = optLi.join(' ');
+                        }
+                    }
+                }
+                // Process Aads
+                const aads = getFirst(grpArmAds.Aads);
+                if (aads && aads.VariousControls && keilTarget.type !== 'C51') {
+                    const a_fopts = getFirst(aads.VariousControls);
+                    if (a_fopts) {
+                        const optLi: string[] = [];
+                        const incText = getFirst(a_fopts.IncludePath);
+                        if (incText && typeof incText === 'string') {
+                            incText.split(';').map((s: string) => s.trim()).filter((s: string) => s).forEach((s: string) => {
+                                optLi.push(`-I${baseInfo.rootFolder.ToRelativePath(s) || s}`);
+                            });
+                        }
+                        const defText = getFirst(a_fopts.Define);
+                        if (defText && typeof defText === 'string') {
+                            defText.replace(/,/g, ' ').split(/\s+/).map((s: string) => s.trim()).filter((s: string) => s).forEach((item: string) => {
+                                optLi.push(`-D${item}`);
+                            });
+                        }
+                        const miscText = getFirst(a_fopts.MiscControls);
+                        if (miscText && typeof miscText === 'string') {
+                            const replMisc = miscText.replace(/(-imacros|-include)\s+([^\s]+)/g, (match: string, p1: string, p2: string) => {
+                                const relp = baseInfo.rootFolder.ToRelativePath(p2) || p2;
+                                return `${p1} ${relp}`;
+                            });
+                            optLi.push(replMisc.trim());
+                        }
+                        if (optLi.length > 0) {
+                            targetSrcOpts.virtualPathFiles = targetSrcOpts.virtualPathFiles || {};
+                            targetSrcOpts.virtualPathFiles[`${vFolderPath}/**/*.{s,S}`] = optLi.join(' ');
+                        }
+                    }
+                }
+            }
+        };
+
         // init file group
         targets[0].fileGroups.forEach((group) => {
             const vPath = `${VirtualSource.rootName}/${File.ToUnixPath(group.name)}`;
             const VFolder = <VirtualFolder>getVirtualFolder(vPath);
+            setupGroupOpts(vPath, group.name);
             group.files.forEach((fileItem) => {
                 // add source file
                 VFolder.files.push({

--- a/src/EIDETypeDefine.ts
+++ b/src/EIDETypeDefine.ts
@@ -233,6 +233,7 @@ export interface FileGroup {
     name: string;       // dir name if it's system folder, else it's a virtual path (with '<virtual_root>/' header)
     files: FileItem[];
     disabled?: boolean;
+    groupOption?: any;
 }
 
 export interface ProjectFileGroup extends FileGroup {

--- a/src/KeilXmlParser.ts
+++ b/src/KeilXmlParser.ts
@@ -230,10 +230,17 @@ export abstract class KeilParser<T> {
         return this._folder.ToRelativePath(path) || path;
     }
 
-    protected FixGroupName(groupName: string): string {
+    /**
+     * Normalize a Keil group name: trim, strip leading slashes, replace \ with /
+     */
+    static FixGroupNameStatic(groupName: string): string {
         return groupName.trim()
-            .replace(/^(?:\\|\/){1,}/, '')  // '/TEST' -> 'TEST'
-            .replace(/\\{1,}/g, '/');       // 'TEST\\A' -> 'TEST/A'
+            .replace(/^(?:\\|\/){1,}/, '')
+            .replace(/\\{1,}/g, '/');
+    }
+
+    protected FixGroupName(groupName: string): string {
+        return KeilParser.FixGroupNameStatic(groupName);
     }
 
     protected isFileDisabled(fileObj: any): boolean | undefined {
@@ -305,6 +312,14 @@ export abstract class KeilParser<T> {
     }
 
     abstract ParseData(): KeilParserResult<T>[];
+
+    /**
+     * Get the raw x2js-parsed XML document for direct access to elements
+     * that may not have been captured in ParseData() results.
+     */
+    getRawDoc(): any {
+        return this.doc;
+    }
 
     abstract SetKeilXml(prj: AbstractProject, fileGroups: FileGroup[], keilOutputDir: File, deviceInfo?: CurrentDevice): void;
 }
@@ -420,11 +435,12 @@ class C51Parser extends KeilParser<KeilC51Option> {
 
             if (groups !== undefined && groups.Group !== undefined) {
 
-                groups.Group.forEach((group: { GroupName: string, Files: any[] }) => {
+                groups.Group.forEach((group: { GroupName: string, Files: any[], GroupOption?: any }) => {
                     const fGroup = <FileGroup>{ name: '', files: [] };
 
                     fGroup.name = this.FixGroupName(group.GroupName);
                     fGroup.disabled = this.isGroupDisabled(group);
+                    if (group.GroupOption) { fGroup.groupOption = group.GroupOption; }
 
                     if (group.Files && group.Files.length > 0) {
 
@@ -1042,11 +1058,12 @@ class ARMParser extends KeilParser<KeilARMOption> {
 
             if (groups !== undefined && groups.Group !== undefined) {
 
-                groups.Group.forEach((group: { GroupName: string, Files: any[] }) => {
+                groups.Group.forEach((group: { GroupName: string, Files: any[], GroupOption?: any }) => {
                     const fGroup = <FileGroup>{ name: '', files: [] };
 
                     fGroup.name = this.FixGroupName(group.GroupName);
                     fGroup.disabled = this.isGroupDisabled(group);
+                    if (group.GroupOption) { fGroup.groupOption = group.GroupOption; }
 
                     if (group.Files && group.Files.length > 0) {
 


### PR DESCRIPTION
问题描述:当前eide无法导入group构建参数到files.options.yml中, 只能打入全局的target的构建参数
实现功能:通过解析keil xml文件, 完成group的提取,并存储到files.options.yml文件中, 用于后续构建命令的使用