### PR TITLE
chore(build): 优化 vsix 打包

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,6 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off",
-    "typescript.tsdk": "node_modules/typescript/lib"
+    "js/ts.tsc.autoDetect": "off",
+    "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,9 +1,10 @@
-.git
+**/.git
 .github
 .vscode
 .vscode-test
 out
 src
+node_modules
 .EIDE
 doc
 **/*.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,33 +1,18 @@
 {
     "name": "eide",
-    "version": "3.26.6",
+    "version": "3.26.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "eide",
-            "version": "3.26.6",
+            "version": "3.26.9",
             "license": "MIT",
-            "dependencies": {
-                "@clangd/vscode-clangd": "^0.0.0",
-                "iconv-lite": "^0.5.0",
-                "ini": "^2.0.0",
-                "jsonc": "^2.0.0",
-                "jsonc-parser": "^3.2.1",
-                "mathjs": "^11.5.0",
-                "micromatch": "^4.0.4",
-                "node-7z": "^3.0.0",
-                "table": "^6.8.1",
-                "vscode-cpptools": "^5.0.0",
-                "x2js": "^3.4.1",
-                "xml-formatter": "^2.6.1",
-                "xml2js": "^0.6.2",
-                "yaml": "2.8.1"
-            },
             "devDependencies": {
                 "@babel/core": "^7.24.7",
                 "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
                 "@babel/preset-env": "^7.24.7",
+                "@clangd/vscode-clangd": "^0.0.0",
                 "@types/ftp": "^0.3.31",
                 "@types/iconv-lite": "0.0.1",
                 "@types/ini": "^1.3.30",
@@ -39,11 +24,24 @@
                 "@types/x2js": "^3.1.0",
                 "@types/xml2js": "^0.4.11",
                 "babel-loader": "^8.3.0",
-                "ts-loader": "^6.2.1",
+                "iconv-lite": "^0.5.0",
+                "ini": "^2.0.0",
+                "jsonc": "^2.0.0",
+                "jsonc-parser": "^3.2.1",
+                "mathjs": "^11.5.0",
+                "micromatch": "^4.0.4",
+                "node-7z": "^3.0.0",
+                "table": "^6.8.1",
+                "ts-loader": "^9.5.7",
                 "tslint": "^5.20.1",
                 "typescript": "^3.7.3",
+                "vscode-cpptools": "^5.0.0",
                 "webpack": "^5.93.0",
-                "webpack-cli": "^5.1.4"
+                "webpack-cli": "^5.1.4",
+                "x2js": "^3.4.1",
+                "xml-formatter": "^2.6.1",
+                "xml2js": "^0.6.2",
+                "yaml": "2.8.1"
             },
             "engines": {
                 "vscode": "^1.67.0"
@@ -1766,6 +1764,7 @@
             "version": "7.20.7",
             "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.20.7.tgz",
             "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+            "dev": true,
             "dependencies": {
                 "regenerator-runtime": "^0.13.11"
             },
@@ -1909,6 +1908,7 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmmirror.com/@clangd/vscode-clangd/-/vscode-clangd-0.0.0.tgz",
             "integrity": "sha512-LqLCmGHxr+xJ9D2Df6NZ7KWTuNSltBu048yyV5qxcRFTMI0B1QPAIymDv4P8ajhR/fCgdXWsXXwrDxiZIhP6Zw==",
+            "dev": true,
             "dependencies": {
                 "vscode-languageclient": "8.0.2"
             }
@@ -2371,6 +2371,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmmirror.com/astral-regex/-/astral-regex-2.0.0.tgz",
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2512,7 +2513,8 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmmirror.com/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
         },
         "node_modules/big.js": {
             "version": "5.2.2",
@@ -2527,6 +2529,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2536,6 +2539,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
             "dependencies": {
                 "fill-range": "^7.1.1"
             },
@@ -2684,6 +2688,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmmirror.com/complex.js/-/complex.js-2.1.1.tgz",
             "integrity": "sha512-8njCHOTtFFLtegk6zQo0kkVX1rngygb/KQI6z1qZxlFI3scluC+LVTCFbrkWjBv4vvLlbQ9t88IPMC6k95VTTg==",
+            "dev": true,
             "engines": {
                 "node": "*"
             },
@@ -2695,7 +2700,8 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmmirror.com/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
         },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
@@ -2716,12 +2722,6 @@
                 "url": "https://opencollective.com/core-js"
             }
         },
-        "node_modules/core-util-is": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmmirror.com/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "dev": true
-        },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2740,6 +2740,7 @@
             "version": "4.3.4",
             "resolved": "https://registry.npmmirror.com/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -2755,7 +2756,8 @@
         "node_modules/decimal.js": {
             "version": "10.4.3",
             "resolved": "https://registry.npmmirror.com/decimal.js/-/decimal.js-10.4.3.tgz",
-            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+            "dev": true
         },
         "node_modules/diff": {
             "version": "4.0.2",
@@ -2782,17 +2784,16 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmmirror.com/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
-            "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmmirror.com/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+            "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
             "dev": true,
             "dependencies": {
-                "graceful-fs": "^4.1.2",
-                "memory-fs": "^0.5.0",
-                "tapable": "^1.0.0"
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.3.3"
             },
             "engines": {
-                "node": ">=6.9.0"
+                "node": ">=10.13.0"
             }
         },
         "node_modules/envinfo": {
@@ -2807,22 +2808,11 @@
                 "node": ">=4"
             }
         },
-        "node_modules/errno": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmmirror.com/errno/-/errno-0.1.8.tgz",
-            "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-            "dev": true,
-            "dependencies": {
-                "prr": "~1.0.1"
-            },
-            "bin": {
-                "errno": "cli.js"
-            }
-        },
         "node_modules/error-ex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmmirror.com/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
@@ -2845,7 +2835,8 @@
         "node_modules/escape-latex": {
             "version": "1.2.0",
             "resolved": "https://registry.npmmirror.com/escape-latex/-/escape-latex-1.2.0.tgz",
-            "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
+            "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==",
+            "dev": true
         },
         "node_modules/escape-string-regexp": {
             "version": "1.0.5",
@@ -2933,7 +2924,8 @@
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
@@ -2944,7 +2936,8 @@
         "node_modules/fast-safe-stringify": {
             "version": "2.1.1",
             "resolved": "https://registry.npmmirror.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "dev": true
         },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
@@ -2959,6 +2952,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -2992,6 +2986,7 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmmirror.com/fraction.js/-/fraction.js-4.2.0.tgz",
             "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+            "dev": true,
             "engines": {
                 "node": "*"
             },
@@ -3060,7 +3055,8 @@
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true
         },
         "node_modules/has": {
             "version": "1.0.3",
@@ -3087,6 +3083,7 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.5.2.tgz",
             "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+            "dev": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3"
             },
@@ -3134,6 +3131,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmmirror.com/ini/-/ini-2.0.0.tgz",
             "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             }
@@ -3150,7 +3148,8 @@
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmmirror.com/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "dev": true
         },
         "node_modules/is-core-module": {
             "version": "2.11.0",
@@ -3168,6 +3167,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -3183,12 +3183,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmmirror.com/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -3208,7 +3202,8 @@
         "node_modules/javascript-natural-sort": {
             "version": "0.7.1",
             "resolved": "https://registry.npmmirror.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
-            "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
+            "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+            "dev": true
         },
         "node_modules/jest-worker": {
             "version": "27.5.1",
@@ -3282,7 +3277,8 @@
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmmirror.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -3296,22 +3292,11 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
-        "node_modules/json5": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
-            "bin": {
-                "json5": "lib/cli.js"
-            }
-        },
         "node_modules/jsonc": {
             "version": "2.0.0",
             "resolved": "https://registry.npmmirror.com/jsonc/-/jsonc-2.0.0.tgz",
             "integrity": "sha512-B281bLCT2TRMQa+AQUQY5AGcqSOXBOKaYGP4wDzoA/+QswUfN8sODektbPEs9Baq7LGKun5jQbNFpzwGuVYKhw==",
+            "dev": true,
             "dependencies": {
                 "fast-safe-stringify": "^2.0.6",
                 "graceful-fs": "^4.1.15",
@@ -3327,7 +3312,8 @@
         "node_modules/jsonc-parser": {
             "version": "3.2.1",
             "resolved": "https://registry.npmmirror.com/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
-            "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA=="
+            "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+            "dev": true
         },
         "node_modules/kind-of": {
             "version": "6.0.3",
@@ -3345,20 +3331,6 @@
             "dev": true,
             "engines": {
                 "node": ">=6.11.5"
-            }
-        },
-        "node_modules/loader-utils": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmmirror.com/loader-utils/-/loader-utils-1.4.2.tgz",
-            "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-            "dev": true,
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=4.0.0"
             }
         },
         "node_modules/locate-path": {
@@ -3382,32 +3354,38 @@
         "node_modules/lodash.defaultsdeep": {
             "version": "4.6.1",
             "resolved": "https://registry.npmmirror.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
-            "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA=="
+            "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
+            "dev": true
         },
         "node_modules/lodash.defaultto": {
             "version": "4.14.0",
             "resolved": "https://registry.npmmirror.com/lodash.defaultto/-/lodash.defaultto-4.14.0.tgz",
-            "integrity": "sha512-G6tizqH6rg4P5j32Wy4Z3ZIip7OfG8YWWlPFzUFGcYStH1Ld0l1tWs6NevEQNEDnO1M3NZYjuHuraaFSN5WqeQ=="
+            "integrity": "sha512-G6tizqH6rg4P5j32Wy4Z3ZIip7OfG8YWWlPFzUFGcYStH1Ld0l1tWs6NevEQNEDnO1M3NZYjuHuraaFSN5WqeQ==",
+            "dev": true
         },
         "node_modules/lodash.flattendeep": {
             "version": "4.4.0",
             "resolved": "https://registry.npmmirror.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-            "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ=="
+            "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+            "dev": true
         },
         "node_modules/lodash.isempty": {
             "version": "4.4.0",
             "resolved": "https://registry.npmmirror.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-            "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg=="
+            "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+            "dev": true
         },
         "node_modules/lodash.negate": {
             "version": "3.0.2",
             "resolved": "https://registry.npmmirror.com/lodash.negate/-/lodash.negate-3.0.2.tgz",
-            "integrity": "sha512-JGJYYVslKYC0tRMm/7igfdHulCjoXjoganRNWM8AgS+RXfOvFnPkOveDhPI65F9aAypCX9QEEQoBqWf7Q6uAeA=="
+            "integrity": "sha512-JGJYYVslKYC0tRMm/7igfdHulCjoXjoganRNWM8AgS+RXfOvFnPkOveDhPI65F9aAypCX9QEEQoBqWf7Q6uAeA==",
+            "dev": true
         },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
             "resolved": "https://registry.npmmirror.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-            "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
+            "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+            "dev": true
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
@@ -3422,6 +3400,7 @@
             "version": "11.5.0",
             "resolved": "https://registry.npmmirror.com/mathjs/-/mathjs-11.5.0.tgz",
             "integrity": "sha512-vJ/+SqWtxjW6/aeDRt8xL3TlOVKqwN15BIyTGVqGbIWuiqgY4SxZ0yLuna82YH9CB757iFP7uJ4m3KvVBX7Qcg==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.6",
                 "complex.js": "^2.1.1",
@@ -3440,19 +3419,6 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/memory-fs": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmmirror.com/memory-fs/-/memory-fs-0.5.0.tgz",
-            "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-            "dev": true,
-            "dependencies": {
-                "errno": "^0.1.3",
-                "readable-stream": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=4.3.0 <5.0.0 || >=5.10"
-            }
-        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3463,6 +3429,7 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmmirror.com/micromatch/-/micromatch-4.0.5.tgz",
             "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "dev": true,
             "dependencies": {
                 "braces": "^3.0.2",
                 "picomatch": "^2.3.1"
@@ -3496,6 +3463,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -3507,6 +3475,7 @@
             "version": "1.2.7",
             "resolved": "https://registry.npmmirror.com/minimist/-/minimist-1.2.7.tgz",
             "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -3515,6 +3484,7 @@
             "version": "0.5.6",
             "resolved": "https://registry.npmmirror.com/mkdirp/-/mkdirp-0.5.6.tgz",
             "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
             "dependencies": {
                 "minimist": "^1.2.6"
             },
@@ -3525,7 +3495,8 @@
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "node_modules/neo-async": {
             "version": "2.6.2",
@@ -3537,6 +3508,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmmirror.com/node-7z/-/node-7z-3.0.0.tgz",
             "integrity": "sha512-KIznWSxIkOYO/vOgKQfJEaXd7rgoFYKZbaurainCEdMhYc7V7mRHX+qdf2HgbpQFcdJL/Q6/XOPrDLoBeTfuZA==",
+            "dev": true,
             "dependencies": {
                 "debug": "^4.3.2",
                 "lodash.defaultsdeep": "^4.6.1",
@@ -3560,6 +3532,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmmirror.com/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3613,6 +3586,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmmirror.com/parse-json/-/parse-json-4.0.0.tgz",
             "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+            "dev": true,
             "dependencies": {
                 "error-ex": "^1.3.1",
                 "json-parse-better-errors": "^1.0.1"
@@ -3664,6 +3638,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -3683,22 +3658,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmmirror.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true
-        },
-        "node_modules/prr": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmmirror.com/prr/-/prr-1.0.1.tgz",
-            "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-            "dev": true
-        },
         "node_modules/punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmmirror.com/punycode/-/punycode-2.1.1.tgz",
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3710,21 +3674,6 @@
             "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
-            }
-        },
-        "node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "dev": true,
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
             }
         },
         "node_modules/rechoir": {
@@ -3760,7 +3709,8 @@
         "node_modules/regenerator-runtime": {
             "version": "0.13.11",
             "resolved": "https://registry.npmmirror.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+            "dev": true
         },
         "node_modules/regenerator-transform": {
             "version": "0.15.2",
@@ -3813,6 +3763,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmmirror.com/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3864,12 +3815,14 @@
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "node_modules/sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmmirror.com/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
         },
         "node_modules/schema-utils": {
             "version": "3.3.0",
@@ -3892,7 +3845,8 @@
         "node_modules/seedrandom": {
             "version": "3.0.5",
             "resolved": "https://registry.npmmirror.com/seedrandom/-/seedrandom-3.0.5.tgz",
-            "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+            "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+            "dev": true
         },
         "node_modules/semver": {
             "version": "6.3.1",
@@ -3949,6 +3903,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmmirror.com/slice-ansi/-/slice-ansi-4.0.0.tgz",
             "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "astral-regex": "^2.0.0",
@@ -3965,6 +3920,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -3979,6 +3935,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -3989,12 +3946,14 @@
         "node_modules/slice-ansi/node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
         },
         "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4024,19 +3983,11 @@
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true
         },
-        "node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmmirror.com/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
         "node_modules/strip-bom": {
             "version": "4.0.0",
             "resolved": "https://registry.npmmirror.com/strip-bom/-/strip-bom-4.0.0.tgz",
             "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4045,6 +3996,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmmirror.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             },
@@ -4080,6 +4032,7 @@
             "version": "6.8.1",
             "resolved": "https://registry.npmmirror.com/table/-/table-6.8.1.tgz",
             "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+            "dev": true,
             "dependencies": {
                 "ajv": "^8.0.1",
                 "lodash.truncate": "^4.4.2",
@@ -4095,6 +4048,7 @@
             "version": "8.12.0",
             "resolved": "https://registry.npmmirror.com/ajv/-/ajv-8.12.0.tgz",
             "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+            "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -4110,6 +4064,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4117,12 +4072,14 @@
         "node_modules/table/node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
         },
         "node_modules/table/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4130,12 +4087,14 @@
         "node_modules/table/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true
         },
         "node_modules/table/node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -4149,6 +4108,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -4157,12 +4117,16 @@
             }
         },
         "node_modules/tapable": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmmirror.com/tapable/-/tapable-1.1.3.tgz",
-            "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmmirror.com/tapable/-/tapable-2.3.3.tgz",
+            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
             "dev": true,
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/terser": {
@@ -4220,7 +4184,8 @@
         "node_modules/tiny-emitter": {
             "version": "2.1.0",
             "resolved": "https://registry.npmmirror.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-            "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+            "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+            "dev": true
         },
         "node_modules/to-fast-properties": {
             "version": "2.0.0",
@@ -4235,6 +4200,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -4243,22 +4209,114 @@
             }
         },
         "node_modules/ts-loader": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmmirror.com/ts-loader/-/ts-loader-6.2.2.tgz",
-            "integrity": "sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==",
+            "version": "9.5.7",
+            "resolved": "https://registry.npmmirror.com/ts-loader/-/ts-loader-9.5.7.tgz",
+            "integrity": "sha512-/ZNrKgA3K3PtpMYOC71EeMWIloGw3IYEa5/t1cyz2r5/PyUwTXGzYJvcD3kfUvmhlfpz1rhV8B2O6IVTQ0avsg==",
             "dev": true,
             "dependencies": {
-                "chalk": "^2.3.0",
-                "enhanced-resolve": "^4.0.0",
-                "loader-utils": "^1.0.2",
+                "chalk": "^4.1.0",
+                "enhanced-resolve": "^5.0.0",
                 "micromatch": "^4.0.0",
-                "semver": "^6.0.0"
+                "semver": "^7.3.4",
+                "source-map": "^0.7.4"
             },
             "engines": {
-                "node": ">=8.6"
+                "node": ">=12.0.0"
             },
             "peerDependencies": {
-                "typescript": "*"
+                "typescript": "*",
+                "webpack": "^5.0.0"
+            }
+        },
+        "node_modules/ts-loader/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ts-loader/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/ts-loader/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/ts-loader/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/ts-loader/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmmirror.com/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ts-loader/node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmmirror.com/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/ts-loader/node_modules/source-map": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmmirror.com/source-map/-/source-map-0.7.6.tgz",
+            "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/ts-loader/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/tslib": {
@@ -4322,6 +4380,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmmirror.com/typed-function/-/typed-function-4.1.0.tgz",
             "integrity": "sha512-DGwUl6cioBW5gw2L+6SMupGwH/kZOqivy17E4nsh1JI9fKF87orMmlQx3KISQPmg3sfnOUGlwVkroosvgddrlg==",
+            "dev": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -4413,20 +4472,16 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmmirror.com/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
-        },
-        "node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmmirror.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true
         },
         "node_modules/vscode-cpptools": {
             "version": "5.0.0",
             "resolved": "https://registry.npmmirror.com/vscode-cpptools/-/vscode-cpptools-5.0.0.tgz",
             "integrity": "sha512-TPG6/o9+DisDj2U4AiTOihtfjEzBb/4CErYaB1JIWFMZTQE7zlNTdsgCs+l4xIS2Y34us0RMBIC6On1mBuwxww==",
+            "dev": true,
             "engines": {
                 "vscode": "^1.22.0"
             }
@@ -4435,6 +4490,7 @@
             "version": "8.0.2",
             "resolved": "https://registry.npmmirror.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
             "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+            "dev": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -4443,6 +4499,7 @@
             "version": "8.0.2",
             "resolved": "https://registry.npmmirror.com/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
             "integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+            "dev": true,
             "dependencies": {
                 "minimatch": "^3.0.4",
                 "semver": "^7.3.5",
@@ -4456,6 +4513,7 @@
             "version": "7.7.4",
             "resolved": "https://registry.npmmirror.com/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -4467,6 +4525,7 @@
             "version": "3.17.2",
             "resolved": "https://registry.npmmirror.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
             "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+            "dev": true,
             "dependencies": {
                 "vscode-jsonrpc": "8.0.2",
                 "vscode-languageserver-types": "3.17.2"
@@ -4475,7 +4534,8 @@
         "node_modules/vscode-languageserver-types": {
             "version": "3.17.2",
             "resolved": "https://registry.npmmirror.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
-            "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+            "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==",
+            "dev": true
         },
         "node_modules/watchpack": {
             "version": "2.4.2",
@@ -4614,28 +4674,6 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/webpack/node_modules/enhanced-resolve": {
-            "version": "5.17.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-            "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.4",
-                "tapable": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "node_modules/webpack/node_modules/tapable": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4667,6 +4705,7 @@
             "version": "3.4.1",
             "resolved": "https://registry.npmjs.org/x2js/-/x2js-3.4.1.tgz",
             "integrity": "sha512-RCMEmHNsyeyzF5NyGHbmCCZU9N8uMiz9FluAj3CpfVREHpgm3JB9Wr/dEWdPqGHmK3lRd2fm0ccOWtuJ2YUowQ==",
+            "dev": true,
             "dependencies": {
                 "xmldom": "^0.5.0"
             }
@@ -4675,6 +4714,7 @@
             "version": "2.6.1",
             "resolved": "https://registry.npmmirror.com/xml-formatter/-/xml-formatter-2.6.1.tgz",
             "integrity": "sha512-dOiGwoqm8y22QdTNI7A+N03tyVfBlQ0/oehAzxIZtwnFAHGeSlrfjF73YQvzSsa/Kt6+YZasKsrdu6OIpuBggw==",
+            "dev": true,
             "dependencies": {
                 "xml-parser-xo": "^3.2.0"
             },
@@ -4686,6 +4726,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmmirror.com/xml-parser-xo/-/xml-parser-xo-3.2.0.tgz",
             "integrity": "sha512-8LRU6cq+d7mVsoDaMhnkkt3CTtAs4153p49fRo+HIB3I1FD1o5CeXRjRH29sQevIfVJIcPjKSsPU/+Ujhq09Rg==",
+            "dev": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -4694,6 +4735,7 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
             "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+            "dev": true,
             "dependencies": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~11.0.0"
@@ -4706,6 +4748,7 @@
             "version": "11.0.1",
             "resolved": "https://registry.npmmirror.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "dev": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -4714,6 +4757,7 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
             "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
+            "dev": true,
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -4728,6 +4772,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmmirror.com/yaml/-/yaml-2.8.1.tgz",
             "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+            "dev": true,
             "bin": {
                 "yaml": "bin.mjs"
             },
@@ -5919,6 +5964,7 @@
             "version": "7.20.7",
             "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.20.7.tgz",
             "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+            "dev": true,
             "requires": {
                 "regenerator-runtime": "^0.13.11"
             }
@@ -6035,6 +6081,7 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmmirror.com/@clangd/vscode-clangd/-/vscode-clangd-0.0.0.tgz",
             "integrity": "sha512-LqLCmGHxr+xJ9D2Df6NZ7KWTuNSltBu048yyV5qxcRFTMI0B1QPAIymDv4P8ajhR/fCgdXWsXXwrDxiZIhP6Zw==",
+            "dev": true,
             "requires": {
                 "vscode-languageclient": "8.0.2"
             }
@@ -6442,7 +6489,8 @@
         "astral-regex": {
             "version": "2.0.0",
             "resolved": "https://registry.npmmirror.com/astral-regex/-/astral-regex-2.0.0.tgz",
-            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+            "dev": true
         },
         "babel-loader": {
             "version": "8.3.0",
@@ -6539,7 +6587,8 @@
         "balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmmirror.com/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
         },
         "big.js": {
             "version": "5.2.2",
@@ -6551,6 +6600,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6560,6 +6610,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
             "requires": {
                 "fill-range": "^7.1.1"
             }
@@ -6658,12 +6709,14 @@
         "complex.js": {
             "version": "2.1.1",
             "resolved": "https://registry.npmmirror.com/complex.js/-/complex.js-2.1.1.tgz",
-            "integrity": "sha512-8njCHOTtFFLtegk6zQo0kkVX1rngygb/KQI6z1qZxlFI3scluC+LVTCFbrkWjBv4vvLlbQ9t88IPMC6k95VTTg=="
+            "integrity": "sha512-8njCHOTtFFLtegk6zQo0kkVX1rngygb/KQI6z1qZxlFI3scluC+LVTCFbrkWjBv4vvLlbQ9t88IPMC6k95VTTg==",
+            "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmmirror.com/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
         },
         "convert-source-map": {
             "version": "2.0.0",
@@ -6680,12 +6733,6 @@
                 "browserslist": "^4.23.0"
             }
         },
-        "core-util-is": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmmirror.com/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "dev": true
-        },
         "cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -6701,6 +6748,7 @@
             "version": "4.3.4",
             "resolved": "https://registry.npmmirror.com/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             }
@@ -6708,7 +6756,8 @@
         "decimal.js": {
             "version": "10.4.3",
             "resolved": "https://registry.npmmirror.com/decimal.js/-/decimal.js-10.4.3.tgz",
-            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+            "dev": true
         },
         "diff": {
             "version": "4.0.2",
@@ -6729,14 +6778,13 @@
             "dev": true
         },
         "enhanced-resolve": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmmirror.com/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
-            "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+            "version": "5.21.0",
+            "resolved": "https://registry.npmmirror.com/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+            "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "memory-fs": "^0.5.0",
-                "tapable": "^1.0.0"
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.3.3"
             }
         },
         "envinfo": {
@@ -6745,19 +6793,11 @@
             "integrity": "sha512-cvcaMr7KqXVh4nyzGTVqTum+gAiL265x5jUWQIDLq//zOGbW+gSW/C+OWLleY/rs9Qole6AZLMXPbtIFQbqu+Q==",
             "dev": true
         },
-        "errno": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmmirror.com/errno/-/errno-0.1.8.tgz",
-            "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-            "dev": true,
-            "requires": {
-                "prr": "~1.0.1"
-            }
-        },
         "error-ex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmmirror.com/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
@@ -6777,7 +6817,8 @@
         "escape-latex": {
             "version": "1.2.0",
             "resolved": "https://registry.npmmirror.com/escape-latex/-/escape-latex-1.2.0.tgz",
-            "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
+            "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==",
+            "dev": true
         },
         "escape-string-regexp": {
             "version": "1.0.5",
@@ -6839,7 +6880,8 @@
         "fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true
         },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
@@ -6850,7 +6892,8 @@
         "fast-safe-stringify": {
             "version": "2.1.1",
             "resolved": "https://registry.npmmirror.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "dev": true
         },
         "fastest-levenshtein": {
             "version": "1.0.16",
@@ -6862,6 +6905,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
@@ -6885,7 +6929,8 @@
         "fraction.js": {
             "version": "4.2.0",
             "resolved": "https://registry.npmmirror.com/fraction.js/-/fraction.js-4.2.0.tgz",
-            "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA=="
+            "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+            "dev": true
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -6934,7 +6979,8 @@
         "graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true
         },
         "has": {
             "version": "1.0.3",
@@ -6955,6 +7001,7 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.5.2.tgz",
             "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+            "dev": true,
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
@@ -6988,7 +7035,8 @@
         "ini": {
             "version": "2.0.0",
             "resolved": "https://registry.npmmirror.com/ini/-/ini-2.0.0.tgz",
-            "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
+            "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+            "dev": true
         },
         "interpret": {
             "version": "3.1.1",
@@ -6999,7 +7047,8 @@
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmmirror.com/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "dev": true
         },
         "is-core-module": {
             "version": "2.11.0",
@@ -7013,7 +7062,8 @@
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -7023,12 +7073,6 @@
             "requires": {
                 "isobject": "^3.0.1"
             }
-        },
-        "isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmmirror.com/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
@@ -7045,7 +7089,8 @@
         "javascript-natural-sort": {
             "version": "0.7.1",
             "resolved": "https://registry.npmmirror.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
-            "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
+            "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+            "dev": true
         },
         "jest-worker": {
             "version": "27.5.1",
@@ -7100,7 +7145,8 @@
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmmirror.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
         },
         "json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -7114,19 +7160,11 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
-        "json5": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.0"
-            }
-        },
         "jsonc": {
             "version": "2.0.0",
             "resolved": "https://registry.npmmirror.com/jsonc/-/jsonc-2.0.0.tgz",
             "integrity": "sha512-B281bLCT2TRMQa+AQUQY5AGcqSOXBOKaYGP4wDzoA/+QswUfN8sODektbPEs9Baq7LGKun5jQbNFpzwGuVYKhw==",
+            "dev": true,
             "requires": {
                 "fast-safe-stringify": "^2.0.6",
                 "graceful-fs": "^4.1.15",
@@ -7139,7 +7177,8 @@
         "jsonc-parser": {
             "version": "3.2.1",
             "resolved": "https://registry.npmmirror.com/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
-            "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA=="
+            "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+            "dev": true
         },
         "kind-of": {
             "version": "6.0.3",
@@ -7152,17 +7191,6 @@
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
             "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
             "dev": true
-        },
-        "loader-utils": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmmirror.com/loader-utils/-/loader-utils-1.4.2.tgz",
-            "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-            "dev": true,
-            "requires": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^1.0.1"
-            }
         },
         "locate-path": {
             "version": "5.0.0",
@@ -7182,32 +7210,38 @@
         "lodash.defaultsdeep": {
             "version": "4.6.1",
             "resolved": "https://registry.npmmirror.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
-            "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA=="
+            "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
+            "dev": true
         },
         "lodash.defaultto": {
             "version": "4.14.0",
             "resolved": "https://registry.npmmirror.com/lodash.defaultto/-/lodash.defaultto-4.14.0.tgz",
-            "integrity": "sha512-G6tizqH6rg4P5j32Wy4Z3ZIip7OfG8YWWlPFzUFGcYStH1Ld0l1tWs6NevEQNEDnO1M3NZYjuHuraaFSN5WqeQ=="
+            "integrity": "sha512-G6tizqH6rg4P5j32Wy4Z3ZIip7OfG8YWWlPFzUFGcYStH1Ld0l1tWs6NevEQNEDnO1M3NZYjuHuraaFSN5WqeQ==",
+            "dev": true
         },
         "lodash.flattendeep": {
             "version": "4.4.0",
             "resolved": "https://registry.npmmirror.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-            "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ=="
+            "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+            "dev": true
         },
         "lodash.isempty": {
             "version": "4.4.0",
             "resolved": "https://registry.npmmirror.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-            "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg=="
+            "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+            "dev": true
         },
         "lodash.negate": {
             "version": "3.0.2",
             "resolved": "https://registry.npmmirror.com/lodash.negate/-/lodash.negate-3.0.2.tgz",
-            "integrity": "sha512-JGJYYVslKYC0tRMm/7igfdHulCjoXjoganRNWM8AgS+RXfOvFnPkOveDhPI65F9aAypCX9QEEQoBqWf7Q6uAeA=="
+            "integrity": "sha512-JGJYYVslKYC0tRMm/7igfdHulCjoXjoganRNWM8AgS+RXfOvFnPkOveDhPI65F9aAypCX9QEEQoBqWf7Q6uAeA==",
+            "dev": true
         },
         "lodash.truncate": {
             "version": "4.4.2",
             "resolved": "https://registry.npmmirror.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-            "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
+            "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+            "dev": true
         },
         "lru-cache": {
             "version": "5.1.1",
@@ -7222,6 +7256,7 @@
             "version": "11.5.0",
             "resolved": "https://registry.npmmirror.com/mathjs/-/mathjs-11.5.0.tgz",
             "integrity": "sha512-vJ/+SqWtxjW6/aeDRt8xL3TlOVKqwN15BIyTGVqGbIWuiqgY4SxZ0yLuna82YH9CB757iFP7uJ4m3KvVBX7Qcg==",
+            "dev": true,
             "requires": {
                 "@babel/runtime": "^7.20.6",
                 "complex.js": "^2.1.1",
@@ -7234,16 +7269,6 @@
                 "typed-function": "^4.1.0"
             }
         },
-        "memory-fs": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmmirror.com/memory-fs/-/memory-fs-0.5.0.tgz",
-            "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-            "dev": true,
-            "requires": {
-                "errno": "^0.1.3",
-                "readable-stream": "^2.0.1"
-            }
-        },
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -7254,6 +7279,7 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmmirror.com/micromatch/-/micromatch-4.0.5.tgz",
             "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "dev": true,
             "requires": {
                 "braces": "^3.0.2",
                 "picomatch": "^2.3.1"
@@ -7278,6 +7304,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -7285,12 +7312,14 @@
         "minimist": {
             "version": "1.2.7",
             "resolved": "https://registry.npmmirror.com/minimist/-/minimist-1.2.7.tgz",
-            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+            "dev": true
         },
         "mkdirp": {
             "version": "0.5.6",
             "resolved": "https://registry.npmmirror.com/mkdirp/-/mkdirp-0.5.6.tgz",
             "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
             "requires": {
                 "minimist": "^1.2.6"
             }
@@ -7298,7 +7327,8 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "neo-async": {
             "version": "2.6.2",
@@ -7310,6 +7340,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmmirror.com/node-7z/-/node-7z-3.0.0.tgz",
             "integrity": "sha512-KIznWSxIkOYO/vOgKQfJEaXd7rgoFYKZbaurainCEdMhYc7V7mRHX+qdf2HgbpQFcdJL/Q6/XOPrDLoBeTfuZA==",
+            "dev": true,
             "requires": {
                 "debug": "^4.3.2",
                 "lodash.defaultsdeep": "^4.6.1",
@@ -7329,7 +7360,8 @@
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmmirror.com/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true
         },
         "once": {
             "version": "1.4.0",
@@ -7368,6 +7400,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmmirror.com/parse-json/-/parse-json-4.0.0.tgz",
             "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+            "dev": true,
             "requires": {
                 "error-ex": "^1.3.1",
                 "json-parse-better-errors": "^1.0.1"
@@ -7406,7 +7439,8 @@
         "picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true
         },
         "pkg-dir": {
             "version": "4.2.0",
@@ -7417,22 +7451,11 @@
                 "find-up": "^4.0.0"
             }
         },
-        "process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmmirror.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true
-        },
-        "prr": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmmirror.com/prr/-/prr-1.0.1.tgz",
-            "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-            "dev": true
-        },
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmmirror.com/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true
         },
         "randombytes": {
             "version": "2.1.0",
@@ -7441,21 +7464,6 @@
             "dev": true,
             "requires": {
                 "safe-buffer": "^5.1.0"
-            }
-        },
-        "readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "dev": true,
-            "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
             }
         },
         "rechoir": {
@@ -7485,7 +7493,8 @@
         "regenerator-runtime": {
             "version": "0.13.11",
             "resolved": "https://registry.npmmirror.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+            "dev": true
         },
         "regenerator-transform": {
             "version": "0.15.2",
@@ -7530,7 +7539,8 @@
         "require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmmirror.com/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true
         },
         "resolve": {
             "version": "1.22.1",
@@ -7567,12 +7577,14 @@
         "safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmmirror.com/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
         },
         "schema-utils": {
             "version": "3.3.0",
@@ -7588,7 +7600,8 @@
         "seedrandom": {
             "version": "3.0.5",
             "resolved": "https://registry.npmmirror.com/seedrandom/-/seedrandom-3.0.5.tgz",
-            "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+            "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+            "dev": true
         },
         "semver": {
             "version": "6.3.1",
@@ -7633,6 +7646,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmmirror.com/slice-ansi/-/slice-ansi-4.0.0.tgz",
             "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+            "dev": true,
             "requires": {
                 "ansi-styles": "^4.0.0",
                 "astral-regex": "^2.0.0",
@@ -7643,6 +7657,7 @@
                     "version": "4.3.0",
                     "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
                     "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
                     "requires": {
                         "color-convert": "^2.0.1"
                     }
@@ -7651,6 +7666,7 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
                     "requires": {
                         "color-name": "~1.1.4"
                     }
@@ -7658,12 +7674,14 @@
                 "color-name": {
                     "version": "1.1.4",
                     "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
                 }
             }
         },
@@ -7689,24 +7707,17 @@
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true
         },
-        "string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmmirror.com/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
         "strip-bom": {
             "version": "4.0.0",
             "resolved": "https://registry.npmmirror.com/strip-bom/-/strip-bom-4.0.0.tgz",
-            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+            "dev": true
         },
         "strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmmirror.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true
         },
         "supports-color": {
             "version": "5.5.0",
@@ -7727,6 +7738,7 @@
             "version": "6.8.1",
             "resolved": "https://registry.npmmirror.com/table/-/table-6.8.1.tgz",
             "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+            "dev": true,
             "requires": {
                 "ajv": "^8.0.1",
                 "lodash.truncate": "^4.4.2",
@@ -7739,6 +7751,7 @@
                     "version": "8.12.0",
                     "resolved": "https://registry.npmmirror.com/ajv/-/ajv-8.12.0.tgz",
                     "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+                    "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -7749,27 +7762,32 @@
                 "ansi-regex": {
                     "version": "5.0.1",
                     "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
-                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+                    "dev": true
                 },
                 "emoji-regex": {
                     "version": "8.0.0",
                     "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
-                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                    "dev": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
                 },
                 "json-schema-traverse": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+                    "dev": true
                 },
                 "string-width": {
                     "version": "4.2.3",
                     "resolved": "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz",
                     "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+                    "dev": true,
                     "requires": {
                         "emoji-regex": "^8.0.0",
                         "is-fullwidth-code-point": "^3.0.0",
@@ -7780,6 +7798,7 @@
                     "version": "6.0.1",
                     "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
                     "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^5.0.1"
                     }
@@ -7787,9 +7806,9 @@
             }
         },
         "tapable": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmmirror.com/tapable/-/tapable-1.1.3.tgz",
-            "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmmirror.com/tapable/-/tapable-2.3.3.tgz",
+            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
             "dev": true
         },
         "terser": {
@@ -7820,7 +7839,8 @@
         "tiny-emitter": {
             "version": "2.1.0",
             "resolved": "https://registry.npmmirror.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-            "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+            "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+            "dev": true
         },
         "to-fast-properties": {
             "version": "2.0.0",
@@ -7832,21 +7852,85 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
             "requires": {
                 "is-number": "^7.0.0"
             }
         },
         "ts-loader": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmmirror.com/ts-loader/-/ts-loader-6.2.2.tgz",
-            "integrity": "sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==",
+            "version": "9.5.7",
+            "resolved": "https://registry.npmmirror.com/ts-loader/-/ts-loader-9.5.7.tgz",
+            "integrity": "sha512-/ZNrKgA3K3PtpMYOC71EeMWIloGw3IYEa5/t1cyz2r5/PyUwTXGzYJvcD3kfUvmhlfpz1rhV8B2O6IVTQ0avsg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.3.0",
-                "enhanced-resolve": "^4.0.0",
-                "loader-utils": "^1.0.2",
+                "chalk": "^4.1.0",
+                "enhanced-resolve": "^5.0.0",
                 "micromatch": "^4.0.0",
-                "semver": "^6.0.0"
+                "semver": "^7.3.4",
+                "source-map": "^0.7.4"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmmirror.com/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.7.4",
+                    "resolved": "https://registry.npmmirror.com/semver/-/semver-7.7.4.tgz",
+                    "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.7.6",
+                    "resolved": "https://registry.npmmirror.com/source-map/-/source-map-0.7.6.tgz",
+                    "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "tslib": {
@@ -7896,7 +7980,8 @@
         "typed-function": {
             "version": "4.1.0",
             "resolved": "https://registry.npmmirror.com/typed-function/-/typed-function-4.1.0.tgz",
-            "integrity": "sha512-DGwUl6cioBW5gw2L+6SMupGwH/kZOqivy17E4nsh1JI9fKF87orMmlQx3KISQPmg3sfnOUGlwVkroosvgddrlg=="
+            "integrity": "sha512-DGwUl6cioBW5gw2L+6SMupGwH/kZOqivy17E4nsh1JI9fKF87orMmlQx3KISQPmg3sfnOUGlwVkroosvgddrlg==",
+            "dev": true
         },
         "typescript": {
             "version": "3.9.10",
@@ -7946,30 +8031,28 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmmirror.com/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
             }
         },
-        "util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmmirror.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true
-        },
         "vscode-cpptools": {
             "version": "5.0.0",
             "resolved": "https://registry.npmmirror.com/vscode-cpptools/-/vscode-cpptools-5.0.0.tgz",
-            "integrity": "sha512-TPG6/o9+DisDj2U4AiTOihtfjEzBb/4CErYaB1JIWFMZTQE7zlNTdsgCs+l4xIS2Y34us0RMBIC6On1mBuwxww=="
+            "integrity": "sha512-TPG6/o9+DisDj2U4AiTOihtfjEzBb/4CErYaB1JIWFMZTQE7zlNTdsgCs+l4xIS2Y34us0RMBIC6On1mBuwxww==",
+            "dev": true
         },
         "vscode-jsonrpc": {
             "version": "8.0.2",
             "resolved": "https://registry.npmmirror.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
-            "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ=="
+            "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+            "dev": true
         },
         "vscode-languageclient": {
             "version": "8.0.2",
             "resolved": "https://registry.npmmirror.com/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
             "integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+            "dev": true,
             "requires": {
                 "minimatch": "^3.0.4",
                 "semver": "^7.3.5",
@@ -7979,7 +8062,8 @@
                 "semver": {
                     "version": "7.7.4",
                     "resolved": "https://registry.npmmirror.com/semver/-/semver-7.7.4.tgz",
-                    "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
+                    "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+                    "dev": true
                 }
             }
         },
@@ -7987,6 +8071,7 @@
             "version": "3.17.2",
             "resolved": "https://registry.npmmirror.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
             "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+            "dev": true,
             "requires": {
                 "vscode-jsonrpc": "8.0.2",
                 "vscode-languageserver-types": "3.17.2"
@@ -7995,7 +8080,8 @@
         "vscode-languageserver-types": {
             "version": "3.17.2",
             "resolved": "https://registry.npmmirror.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
-            "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+            "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==",
+            "dev": true
         },
         "watchpack": {
             "version": "2.4.2",
@@ -8037,24 +8123,6 @@
                 "terser-webpack-plugin": "^5.3.10",
                 "watchpack": "^2.4.1",
                 "webpack-sources": "^3.2.3"
-            },
-            "dependencies": {
-                "enhanced-resolve": {
-                    "version": "5.17.1",
-                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-                    "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.2.4",
-                        "tapable": "^2.2.0"
-                    }
-                },
-                "tapable": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-                    "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-                    "dev": true
-                }
             }
         },
         "webpack-cli": {
@@ -8128,6 +8196,7 @@
             "version": "3.4.1",
             "resolved": "https://registry.npmjs.org/x2js/-/x2js-3.4.1.tgz",
             "integrity": "sha512-RCMEmHNsyeyzF5NyGHbmCCZU9N8uMiz9FluAj3CpfVREHpgm3JB9Wr/dEWdPqGHmK3lRd2fm0ccOWtuJ2YUowQ==",
+            "dev": true,
             "requires": {
                 "xmldom": "^0.5.0"
             }
@@ -8136,6 +8205,7 @@
             "version": "2.6.1",
             "resolved": "https://registry.npmmirror.com/xml-formatter/-/xml-formatter-2.6.1.tgz",
             "integrity": "sha512-dOiGwoqm8y22QdTNI7A+N03tyVfBlQ0/oehAzxIZtwnFAHGeSlrfjF73YQvzSsa/Kt6+YZasKsrdu6OIpuBggw==",
+            "dev": true,
             "requires": {
                 "xml-parser-xo": "^3.2.0"
             }
@@ -8143,12 +8213,14 @@
         "xml-parser-xo": {
             "version": "3.2.0",
             "resolved": "https://registry.npmmirror.com/xml-parser-xo/-/xml-parser-xo-3.2.0.tgz",
-            "integrity": "sha512-8LRU6cq+d7mVsoDaMhnkkt3CTtAs4153p49fRo+HIB3I1FD1o5CeXRjRH29sQevIfVJIcPjKSsPU/+Ujhq09Rg=="
+            "integrity": "sha512-8LRU6cq+d7mVsoDaMhnkkt3CTtAs4153p49fRo+HIB3I1FD1o5CeXRjRH29sQevIfVJIcPjKSsPU/+Ujhq09Rg==",
+            "dev": true
         },
         "xml2js": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
             "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+            "dev": true,
             "requires": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~11.0.0"
@@ -8157,12 +8229,14 @@
         "xmlbuilder": {
             "version": "11.0.1",
             "resolved": "https://registry.npmmirror.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "dev": true
         },
         "xmldom": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-            "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
+            "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
+            "dev": true
         },
         "yallist": {
             "version": "3.1.1",
@@ -8173,7 +8247,8 @@
         "yaml": {
             "version": "2.8.1",
             "resolved": "https://registry.npmmirror.com/yaml/-/yaml-2.8.1.tgz",
-            "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw=="
+            "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+            "dev": true
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
         "@babel/core": "^7.24.7",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
         "@babel/preset-env": "^7.24.7",
+        "@clangd/vscode-clangd": "^0.0.0",
         "@types/ftp": "^0.3.31",
         "@types/iconv-lite": "0.0.1",
         "@types/ini": "^1.3.30",
@@ -89,14 +90,6 @@
         "@types/x2js": "^3.1.0",
         "@types/xml2js": "^0.4.11",
         "babel-loader": "^8.3.0",
-        "ts-loader": "^6.2.1",
-        "tslint": "^5.20.1",
-        "typescript": "^3.7.3",
-        "webpack": "^5.93.0",
-        "webpack-cli": "^5.1.4"
-    },
-    "dependencies": {
-        "@clangd/vscode-clangd": "^0.0.0",
         "iconv-lite": "^0.5.0",
         "ini": "^2.0.0",
         "jsonc": "^2.0.0",
@@ -105,12 +98,18 @@
         "micromatch": "^4.0.4",
         "node-7z": "^3.0.0",
         "table": "^6.8.1",
+        "ts-loader": "^6.2.1",
+        "tslint": "^5.20.1",
+        "typescript": "^3.7.3",
         "vscode-cpptools": "^5.0.0",
+        "webpack": "^5.93.0",
+        "webpack-cli": "^5.1.4",
         "x2js": "^3.4.1",
         "xml-formatter": "^2.6.1",
         "xml2js": "^0.6.2",
         "yaml": "2.8.1"
     },
+    "dependencies": {},
     "contributes": {
         "terminal": {
             "profiles": [

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
         "micromatch": "^4.0.4",
         "node-7z": "^3.0.0",
         "table": "^6.8.1",
-        "ts-loader": "^6.2.1",
+        "ts-loader": "^9.5.7",
         "tslint": "^5.20.1",
         "typescript": "^3.7.3",
         "vscode-cpptools": "^5.0.0",
@@ -109,7 +109,6 @@
         "xml2js": "^0.6.2",
         "yaml": "2.8.1"
     },
-    "dependencies": {},
     "contributes": {
         "terminal": {
             "profiles": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,58 +4,54 @@
 
 const path = require('path');
 
-const config = {
-    target: 'node',
-    entry: './src/extension.ts',
-    output: {
-        path: path.resolve(__dirname, 'dist'),
-        filename: 'extension.js',
-        libraryTarget: 'commonjs2',
-        devtoolModuleFilenameTemplate: '../[resource-path]'
-    },
-    devtool: 'source-map',
-    externals: {
-        vscode: 'commonjs vscode',
-        x2js: 'x2js',
-        iconv_lite: 'iconv-lite',
-        jsonc: 'jsonc',
-        ini: 'ini',
-        yaml: 'yaml',
-        unzipper: 'unzipper',
-        jsonc_parser: 'jsonc-parser'
-    },
-    resolve: {
-        // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
-        extensions: ['.ts', '.js']
-    },
-    module: {
-        rules: [
-            {
-                test: /\.m?js$/,
-                include: [
-                    path.resolve(__dirname, 'node_modules/jsonc-parser/lib')
-                ],
-                use: {
-                    loader: 'babel-loader',
-                    options: {
-                        presets: ['@babel/preset-env'],
-                        plugins: [
-                            //'@babel/plugin-proposal-object-rest-spread',
-                            '@babel/plugin-proposal-nullish-coalescing-operator'
-                        ],
+/** @type {(env: any, argv: { mode?: string }) => import('webpack').Configuration} */
+module.exports = (env, argv) => {
+    const isProduction = argv && argv.mode === 'production';
+
+    return {
+        target: 'node',
+        entry: './src/extension.ts',
+        output: {
+            path: path.resolve(__dirname, 'dist'),
+            filename: 'extension.js',
+            libraryTarget: 'commonjs2',
+            devtoolModuleFilenameTemplate: '../[resource-path]'
+        },
+        devtool: isProduction ? false : 'source-map',
+        externals: {
+            vscode: 'commonjs vscode'
+        },
+        resolve: {
+            // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
+            extensions: ['.ts', '.js']
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.m?js$/,
+                    include: [
+                        path.resolve(__dirname, 'node_modules/jsonc-parser/lib')
+                    ],
+                    use: {
+                        loader: 'babel-loader',
+                        options: {
+                            presets: ['@babel/preset-env'],
+                            plugins: [
+                                '@babel/plugin-proposal-nullish-coalescing-operator'
+                            ],
+                        },
                     },
                 },
-            },
-            {
-                test: /\.ts$/,
-                exclude: /node_modules/,
-                use: [
-                    {
-                        loader: 'ts-loader'
-                    }
-                ]
-            }
-        ]
-    }
+                {
+                    test: /\.ts$/,
+                    exclude: /node_modules/,
+                    use: [
+                        {
+                            loader: 'ts-loader'
+                        }
+                    ]
+                }
+            ]
+        }
+    };
 };
-module.exports = config;


### PR DESCRIPTION
执行 `vsce package` 时报警告：
```
This extension consists of 4167 files, out of which 3411 are JavaScript files. For performance reasons, you should bundle your extension.
```
两条 webpack 弃用警告：
```
DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET: Compilation.modules was changed from Array to Set
DEP_WEBPACK_MODULE_ERRORS: Module.errors was removed (use getErrors instead)
```

### 问题

1. **依赖被双份打包**：webpack 已经把绝大多数依赖编译进了 `dist/extension.js`，但因为 `package.json` 的 `dependencies` 字段非空，vsce 会再把所有生产依赖的 `node_modules` 树原样复制进 vsix。
2. **webpack `externals` 有两处 bug**：
   - `iconv_lite` / `jsonc_parser` 用了下划线 key，与实际 import 字符串 `iconv-lite` / `jsonc-parser` 不匹配，规则永远不命中。这两个包仍然被 bundle，但同时又随 `dependencies` 被多复制了一份。
   - `unzipper` 出现在 `externals` 中，但项目根本没有这个依赖（`src/ResInstaller.ts` 中只是恰巧有同名局部变量），是死规则。
3. **webpack 弃用警告来自 `ts-loader@6.2.2`**：`--trace-deprecation` 显示堆栈指向 `ts-loader/dist/after-compile.js`。该版本针对 webpack 4 设计，在 webpack 5 下使用了已废弃的 `Compilation.modules` 数组与 `Module.errors` API。

### 改动

**1. `webpack.config.js`**
- 配置改写为函数形式，按 mode 生成。
- `externals` 只保留 `vscode`，其余依赖由 webpack 内联打包。
- `devtool` 按模式切换：production 关闭 source map，development 仍生成。
- 移除拼写错误的 `iconv_lite` / `jsonc_parser` 与死规则 `unzipper`。

**2. `package.json`**
- 全部 14 项 `dependencies` 移入 `devDependencies`（这些纯 JS 包均已被 webpack bundle，运行时无需在 `node_modules` 中独立存在）。`dependencies` 留空，使 vsce 默认行为也不会再复制 `node_modules`。
- `ts-loader: ^6.2.1` → `^9.5.1`。ts-loader 9.x 原生支持 webpack 5。

**3. `.vscodeignore`**
- `.git` 改为 `**/.git`：原规则只匹配根目录。`lib/node-utility/.git` 被包进 vsix。
- 增加 `node_modules`


|  | 改前 | 改后 |
|---|---:|---:|
| vsix 文件总数 | 4066 | 385 |
| vsix 体积 | 28.11 MB | 23.5 MB |
| `DEP_WEBPACK` 警告 | 2 条 | 0 |
| vsce 打包警告 | 1 条 | 0 |

### 兼容性

- 所有原 `dependencies` 都是纯 JS（无 native module），bundle 后行为一致。
- ts-loader 9.x 与现有 TypeScript 3.9、`tsconfig.json` 配置兼容。